### PR TITLE
Fix mimetype

### DIFF
--- a/src/Oro/Bundle/ImportExportBundle/File/FileManager.php
+++ b/src/Oro/Bundle/ImportExportBundle/File/FileManager.php
@@ -242,8 +242,14 @@ class FileManager
             $file = $file->getKey();
         }
 
-        if ($file && $this->filesystem->has($file)) {
-            return $this->filesystem->mimeType($file);
+	if ($file && $this->filesystem->has($file)) {
+	    try {
+                return $this->filesystem->mimeType($file);
+	    } catch (\LogicException $e) {
+		// The underlying adapter does support mimetype.
+		return null;
+	    }
+
         }
 
         return null;


### PR DESCRIPTION
If the underlying adapter does not support mimetype, than it should return `null`.